### PR TITLE
Don't store secret keys in the repository

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+SECRET_KEY_BASE=change_me_in_production

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :test, :development do
   gem 'database_cleaner'
   gem 'factory_girl_rails'
   gem 'capybara-webkit'
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,9 @@ GEM
     database_cleaner (1.2.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
+    dotenv (0.9.0)
+    dotenv-rails (0.9.0)
+      dotenv (= 0.9.0)
     erubis (2.7.0)
     execjs (2.0.2)
     factory_girl (4.3.0)
@@ -174,6 +177,7 @@ DEPENDENCIES
   capybara-webkit
   coffee-rails (~> 4.0.0)
   database_cleaner
+  dotenv-rails
   factory_girl_rails
   haml-rails
   jbuilder (~> 1.2)

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -10,11 +10,11 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
+default: &default
+  secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
 development:
-  secret_key_base: 6a0be16ae3b5e908c390499a94cf1e6aea90b7980651cf4e4187c1c3d5337d6ad933ec27cecd8d33094c5dc902e517fd4c7e6fab7158e1cc2781aa103e7222ca
-
+  <<: *default
 test:
-  secret_key_base: 0347e00360ed02c00aa4abe82ddc98f6280e96ecda86e7f990e56a732ca6791d2f79bc891fec2c1017665e105ca73b93cdc6dad19dc73bd8039490e9df904aea
-
+  <<: *default
 production:
-  secret_key_base: 426c3389be100511f2cfc7b21fdf07c27ac77f01545abbe0cb168c2e6a4fd1b88905e37a849dba03b37f002bf1db8c9d9f947a7a8a4a6c4245705658edf48947
+  <<: *default


### PR DESCRIPTION
Storing secret session keys in the repository is a huge security issue.
We're now using environment variables for it. In production, we'll need to define `SECRET_KEY_BASE`.
