### PR TITLE
Don't use URIs to version the API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'haml-rails'
 gem 'wisper',         '~>1.2.0'
 gem 'bootstrap-sass', '~> 3.0.3.0'
 gem 'draper',         '~> 1.3'
+gem 'biceps',         '~> 0.0.5'
 
 group :test, :development do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,9 @@ GEM
     better_errors (1.0.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
+    biceps (0.0.5)
+      rails (>= 3.0.0)
+      rake (>= 0.8.7)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.0.3.0)
@@ -183,6 +186,7 @@ PLATFORMS
 
 DEPENDENCIES
   better_errors
+  biceps (~> 0.0.5)
   binding_of_caller (>= 0.7.2)
   bootstrap-sass (~> 3.0.3.0)
   capybara (~> 2.2.0)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   namespace :api do
-    namespace :v1 do
+    api_version(1) do
       resources :results
     end
   end

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ $ rails c
 Then you can post your results for a run, here is a sample cURL request that should work:
 
 ```
-curl -i -H 'Content-Type: application/json' -H 'Authorization: Token token="123"' -X POST http://localhost:3000/api/v1/results -d "{\"run\":{\"ruby_version\":\"2.0.0-p247\",\"git_hash\":\"c0a04be8ddcadcd89c02bc135e4b288f6d936704\",\"date\":\"2013-12-18T12:09:16+00:00\",\"results_attributes\":[{\"benchmark\":\"some_bench\",\"score\":\"222\"}]}}"
+curl -i -H 'Content-Type: application/json' -H 'Accept: 'application/json,application/vnd.ruby_bench;ver=1' -H 'Authorization: Token token="123"' -X POST http://localhost:3000/api/results -d "{\"run\":{\"ruby_version\":\"2.0.0-p247\",\"git_hash\":\"c0a04be8ddcadcd89c02bc135e4b288f6d936704\",\"date\":\"2013-12-18T12:09:16+00:00\",\"results_attributes\":[{\"benchmark\":\"some_bench\",\"score\":\"222\"}]}}"
 ```
 
 Here are the response codes you should expect:

--- a/spec/requests/api/receiving_results_spec.rb
+++ b/spec/requests/api/receiving_results_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
 describe "Receiving results" do
-  describe "POST /api/v1/results" do
+  describe "POST API /api/results" do
     let(:runner) { create(:runner) }
-    let(:token) {{ "Authorization" => "Token token=\"#{runner.token}\"" }}
+    let(:headers) {{ "Authorization" => "Token token=\"#{runner.token}\"", "Accept" => "application/json,application/vnd.ruby_bench;ver=1" }}
 
     let(:params) do
       {
@@ -23,7 +23,7 @@ describe "Receiving results" do
       let(:run) { runner.runs.first }
 
       before do
-        post api_v1_results_path, params, token
+        post api_results_path, params, headers
       end
 
       it "returns a 204 status" do
@@ -53,7 +53,7 @@ describe "Receiving results" do
     context "when invalid data is provided" do
       context "when no runner token is provided" do
         before do
-          post api_v1_results_path, params
+          post api_results_path, params, {"Accept" => "application/json,application/vnd.ruby_bench;ver=1"}
         end
 
         it_behaves_like "an unauthorized request"
@@ -62,7 +62,7 @@ describe "Receiving results" do
 
       context "when runner token is invalid" do
         before do
-          post api_v1_results_path, params, { "Authorization" => 'Token token="derp"' }
+          post api_results_path, params, { "Authorization" => 'Token token="derp"', "Accept" => "application/json,application/vnd.ruby_bench;ver=1" }
         end
 
         it_behaves_like "an unauthorized request"
@@ -72,7 +72,7 @@ describe "Receiving results" do
       context "when run details are invalid" do
         before do
           params[:run][:ruby_version] = ""
-          post api_v1_results_path, params, token
+          post api_results_path, params, headers
         end
 
         it_behaves_like "an invalid request"
@@ -82,7 +82,7 @@ describe "Receiving results" do
       context "when run benchmarks are invalid" do
         before do
           params[:run][:results_attributes].first[:benchmark] = ""
-          post api_v1_results_path, params, token
+          post api_results_path, params, headers
         end
 
         it_behaves_like "an invalid request"


### PR DESCRIPTION
This is a bit opinionated, sorry.
The API version number is better put into the HTTP Accept header rather than the URI.

See this for a handful or arguments: http://pivotallabs.com/api-versioning/
