### PR TITLE
Fixes mistaken rename of secret key base env var.

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,10 +11,10 @@
 # if you're sharing your code publicly.
 
 default: &default
-  secret_key_base: <%= ENV['SECRET_TOKEN'] || "CHUNKYBACON" * 3 %>
+  secret_key_base: <%= ENV['SECRET_KEY_BASE'] || "CHUNKYBACON" * 3 %>
 development:
   <<: *default
 test:
   <<: *default
 production:
-  secret_key_base: <%= ENV['SECRET_TOKEN'] %>
+  secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>


### PR DESCRIPTION
That's what you get for copy and pasting :poop:
